### PR TITLE
Ensures that guard environment is only used for guards in `scase`. 

### DIFF
--- a/lib/solution.ex
+++ b/lib/solution.ex
@@ -276,12 +276,13 @@ defmodule Solution do
       case node do
         {:->, meta, [[lhs], rhs]} ->
           {lhs, rhs_list} = expand_match(lhs, [rhs])
+          lhs = Macro.expand(lhs, guard_env)
           rhs = {:__block__, [], rhs_list}
           node = {:->, meta, [[lhs], rhs]}
           Macro.expand(node, guard_env)
 
-        _ ->
-          Macro.expand(node, guard_env)
+        other ->
+          Macro.expand(other, __CALLER__)
       end
     end)
   end

--- a/lib/solution.ex
+++ b/lib/solution.ex
@@ -366,7 +366,7 @@ defmodule Solution do
   defmacro swith(statements, conditions)
 
   defmacro swith(statement, conditions) do
-    do_swith([statement], conditions)
+    do_swith([statement], conditions, __CALLER__)
   end
 
   # Since `swith` is a normal macro bound to normal function rules,
@@ -375,11 +375,11 @@ defmodule Solution do
     args = 0..arg_num |> Enum.map(fn num -> Macro.var(:"statement#{num}", __MODULE__) end)
     @doc false
     defmacro swith(unquote_splicing(args), conditions) do
-      do_swith(unquote(args), conditions)
+      do_swith(unquote(args), conditions, __CALLER__)
     end
   end
 
-  defp do_swith(statements, conditions) do
+  defp do_swith(statements, conditions, caller_env) do
     guard_env = Map.put(__ENV__, :context, :guard)
 
     statements =
@@ -393,8 +393,8 @@ defmodule Solution do
 
             [node | extra_statements]
 
-          _ ->
-            [Macro.expand(node, guard_env)]
+          other ->
+            [Macro.expand(other, caller_env)]
         end
       end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Solution.MixProject do
   def project do
     [
       app: :solution,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Ensures that the guard environment is only used for guards in `scase`.
Other environments now properly use `__CALLER__`.

This mainly means that aliases will now work correctly (Fixes #2).
